### PR TITLE
chore: Changes name to namecheap-lego-k8s

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         with:
           name: tested-charm
-          path: .tox/**/namecheap-acme-operator_ubuntu-22.04-amd64.charm
+          path: .tox/**/namecheap-lego-k8s_ubuntu-22.04-amd64.charm
           retention-days: 5
       - name: Archive charmcraft logs
         if: failure()
@@ -89,7 +89,7 @@ jobs:
         with:
           name: tested-charm
       - name: Move charm in current directory
-        run: find ./ -name namecheap-acme-operator_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
+        run: find ./ -name namecheap-lego-k8s_ubuntu-22.04-amd64.charm -exec mv -t ./ {} \;
       - name: Select Charmhub channel
         uses: canonical/charming-actions/channel@2.4.0
         id: channel

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Namecheap ACME Operator (K8s)
-[![CharmHub Badge](https://charmhub.io/namecheap-acme-operator/badge.svg)](https://charmhub.io/namecheap-acme-operator)
+# Namecheap LEGO Operator (K8s)
+[![CharmHub Badge](https://charmhub.io/namecheap-lego-k8s/badge.svg)](https://charmhub.io/namecheap-lego-k8s)
 
 Let's Encrypt certificates in the Juju ecosystem for Namecheap users.
 
@@ -12,22 +12,22 @@ Charms that require those certificates need to implement the requirer side of th
 Create a YAML configuration file with the following fields:
 
 ```yaml
-namecheap-acme-operator:
+namecheap-lego-k8s:
   email: <Account email address>
   namecheap-username: <Namecheap API user>
   namecheap-api-key: <Namecheap API key>
 ```
 
-Deploy `namecheap-acme-operator`:
+Deploy `namecheap-lego-k8s`:
 
 ```bash
-juju deploy namecheap-acme-operator --config <yaml config file>
+juju deploy namecheap-lego-k8s --config <yaml config file>
 ```
 
 Relate it to a `tls-certificates-requirer` charm:
 
 ```bash
-juju relate namecheap-acme-operator:certificates <tls-certificates-requirer>
+juju relate namecheap-lego-k8s:certificates <tls-certificates-requirer>
 ```
 
 ## Config

--- a/lib/charms/lego_base_k8s/v0/lego_client.py
+++ b/lib/charms/lego_base_k8s/v0/lego_client.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""# acme_client Library.
+"""# lego_client Library.
 
 This library is designed to enable developers to easily create new charms for the ACME protocol.
 This library contains all the logic necessary to get certificates from an ACME server.
@@ -9,7 +9,7 @@ This library contains all the logic necessary to get certificates from an ACME s
 ## Getting Started
 To get started using the library, you need to fetch the library using `charmcraft`.
 ```shell
-charmcraft fetch-lib charms.acme_client_operator.v0.acme_client
+charmcraft fetch-lib charms.lego_client_operator.v0.lego_client
 ```
 You will also need to add the following library to the charm's `requirements.txt` file:
 - jsonschema
@@ -17,7 +17,7 @@ You will also need to add the following library to the charm's `requirements.txt
 
 Then, to use the library in an example charm, you can do the following:
 ```python
-from charms.acme_client_operator.v0.acme_client import AcmeClient
+from charms.lego_client_operator.v0.lego_client import AcmeClient
 from ops.main import main
 class ExampleAcmeCharm(AcmeClient):
     def __init__(self, *args):
@@ -78,14 +78,15 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from ops.pebble import ExecError
 
 # The unique Charmhub library identifier, never change it
-LIBID = "b3c9913b68dc42b89dfd0e77ac57236d"
+LIBID = "d67f92a288e54ab68a6b6349e9b472c4"
 
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 1
+
 
 logger = logging.getLogger(__name__)
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,19 +1,19 @@
 # Copyright 2022 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-name: namecheap-acme-operator
+name: namecheap-lego-k8s
 
-display-name: Namecheap ACME Operator
+display-name: Namecheap LEGO Operator (K8s)
 
 description: |
-  ACME operator implementing the provider side of the `tls-certificates`
+  LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server using namecheap DNS.
 summary: |
-  ACME operator implementing the provider side of the `tls-certificates`
+  LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server using namecheap DNS.
 website: https://charmhub.io/namecheap-acme-operator
-source: https://github.com/canonical/namecheap-acme-operator
-issues: https://github.com/canonical/namecheap-acme-operator/issues
+source: https://github.com/canonical/namecheap-lego-k8s-operator
+issues: https://github.com/canonical/namecheap-lego-k8s-operator/issues
 docs: https://discourse.charmhub.io/t/namecheap-acme-operator-docs-index/12521
 
 provides:

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,18 +7,18 @@
 import logging
 from typing import Dict, Optional
 
-from charms.acme_client_operator.v0.acme_client import AcmeClient  # type: ignore[import]
+from charms.lego_base_k8s.v0.lego_client import AcmeClient  # type: ignore[import]
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
 
 logger = logging.getLogger(__name__)
 
 
-class NamecheapAcmeOperatorCharm(AcmeClient):
+class NamecheapLegoK8s(AcmeClient):
     """Main class that is instantiated every time an event occurs."""
 
     def __init__(self, *args):
-        """Uses the acme_client library to manage events."""
+        """Uses the lego_client library to manage events."""
         super().__init__(*args, plugin="namecheap")
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
@@ -95,4 +95,4 @@ class NamecheapAcmeOperatorCharm(AcmeClient):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(NamecheapAcmeOperatorCharm)
+    main(NamecheapLegoK8s)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -6,12 +6,12 @@ import unittest
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
-from charm import NamecheapAcmeOperatorCharm
+from charm import NamecheapLegoK8s
 
 
 class TestCharm(unittest.TestCase):
     def setUp(self):
-        self.harness = Harness(NamecheapAcmeOperatorCharm)
+        self.harness = Harness(NamecheapLegoK8s)
         self.harness.set_leader(True)
         self.harness.set_can_connect("lego", True)
         self.addCleanup(self.harness.cleanup)


### PR DESCRIPTION
# Description

This PR changes the charm name from `namecheap-acme-operator` to `namecheap-lego-k8s` in order to follow the charm naming convention.

## Reference
- https://docs.google.com/document/d/1R0UzoPr3vvorhbBJYBz-5gZkTCTL2a9_R6xV8K4_i-8/edit
- https://juju.is/docs/sdk/naming

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
