### PR TITLE
chore: Removes documentation from README and link to docs on Charmhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 LEGO operator implementing the provider side of the 
 [`tls-certificates` interface](https://github.com/canonical/tls-certificates-interface) 
 to get signed certificates from the `Let's Encrypt` ACME server
-using [NAMECHEAP](https://go-acme.github.io/lego/dns/namecheap/) plugin and the DNS-01 challenge.
+using [Namecheap](https://go-acme.github.io/lego/dns/namecheap/) plugin and the DNS-01 challenge.
 
 For more information including guides, integrations, configuration options, see [Namecheap LEGO's Charmhub page](https://charmhub.io/namecheap-lego-k8s).
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,12 @@
 # Namecheap LEGO Operator (K8s)
 [![CharmHub Badge](https://charmhub.io/namecheap-lego-k8s/badge.svg)](https://charmhub.io/namecheap-lego-k8s)
 
-Let's Encrypt certificates in the Juju ecosystem for Namecheap users.
+LEGO operator implementing the provider side of the 
+[`tls-certificates` interface](https://github.com/canonical/tls-certificates-interface) 
+to get signed certificates from the `Let's Encrypt` ACME server
+using [NAMECHEAP](https://go-acme.github.io/lego/dns/namecheap/) plugin and the DNS-01 challenge.
 
-## Pre-requisites
-
-Charms that require those certificates need to implement the requirer side of the [`tls-certificates-interface`](https://github.com/canonical/tls-certificates-interface).
-
-## Usage
-
-Create a YAML configuration file with the following fields:
-
-```yaml
-namecheap-lego-k8s:
-  email: <Account email address>
-  namecheap-username: <Namecheap API user>
-  namecheap-api-key: <Namecheap API key>
-```
-
-Deploy `namecheap-lego-k8s`:
-
-```bash
-juju deploy namecheap-lego-k8s --config <yaml config file>
-```
-
-Relate it to a `tls-certificates-requirer` charm:
-
-```bash
-juju relate namecheap-lego-k8s:certificates <tls-certificates-requirer>
-```
-
-## Config
-
-### Required configuration properties
-
-- email: Account email address
-- namecheap-username: Namecheap API user
-- namecheap-api-key: Namecheap API key
-
-### Optional configuration properties
-
-- server: Let's Encrypt server to use (default: `https://acme-v02.api.letsencrypt.org/directory`)
-- namecheap-http-timeout: API request timeout in seconds (default: `60`)
-- namecheap-polling-interval: Time between DNS propagation checks in seconds (default: `15`)
-- namecheap-propagation-timeout: Maximum waiting time for DNS propagation in seconds (default: `3600`)
-- namecheap-ttl: The TTL of the TXT record used for the DNS challenge in seconds (default: `120`)
-- namecheap-sandbox: Use Namecheap sandbox API (default: `false`)
-
-
-## Relations
-
-`certificates`: `tls-certificates-interface` provider
+For more information including guides, integrations, configuration options, see [Namecheap LEGO's Charmhub page](https://charmhub.io/namecheap-lego-k8s).
 
 ## OCI Images
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   email:
     type: string
-    description: Account email address.
+    description: Account email address to receive notifications from Let's Encrypt
   server:
     type: string
     description: The ACME server URL.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -7,10 +7,12 @@ display-name: Namecheap LEGO Operator (K8s)
 
 description: |
   LEGO operator implementing the provider side of the `tls-certificates`
-  interface to get signed certificates from the `Let's Encrypt` ACME server using namecheap DNS.
+  interface to get signed certificates from the `Let's Encrypt` ACME server
+  using NAMECHEAP plugin and the DNS-01 challenge.
 summary: |
   LEGO operator implementing the provider side of the `tls-certificates`
-  interface to get signed certificates from the `Let's Encrypt` ACME server using namecheap DNS.
+  interface to get signed certificates from the `Let's Encrypt` ACME server
+  using NAMECHEAP plugin and the DNS-01 challenge.
 website: https://charmhub.io/namecheap-lego-k8s
 source: https://github.com/canonical/namecheap-lego-k8s-operator
 issues: https://github.com/canonical/namecheap-lego-k8s-operator/issues

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,11 +8,11 @@ display-name: Namecheap LEGO Operator (K8s)
 description: |
   LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
-  using NAMECHEAP plugin and the DNS-01 challenge.
+  using Namecheap plugin and the DNS-01 challenge.
 summary: |
   LEGO operator implementing the provider side of the `tls-certificates`
   interface to get signed certificates from the `Let's Encrypt` ACME server
-  using NAMECHEAP plugin and the DNS-01 challenge.
+  using Namecheap plugin and the DNS-01 challenge.
 website: https://charmhub.io/namecheap-lego-k8s
 source: https://github.com/canonical/namecheap-lego-k8s-operator
 issues: https://github.com/canonical/namecheap-lego-k8s-operator/issues


### PR DESCRIPTION
# Description

Improves the README, metadata and config files

Note for reviewers:
Please take a look at the enhanced docs in Charmhub:
https://discourse.charmhub.io/t/namecheap-lego-operator-k8s-docs-index/12521

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
