### PR TITLE
chore: use ruff for linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,20 +14,33 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"
+
+[tool.pyright]
+include = ["src/**.py"]

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,8 @@
 import logging
 from typing import Dict, Optional
 
-from charms.lego_base_k8s.v0.lego_client import AcmeClient  # type: ignore[import]
+from charms.lego_base_k8s.v0.lego_client import AcmeClient
+from ops.framework import EventBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
 
@@ -18,17 +19,17 @@ class NamecheapLegoK8s(AcmeClient):
     """Main class that is instantiated every time an event occurs."""
 
     def __init__(self, *args):
-        """Uses the lego_client library to manage events."""
+        """Use the lego_client library to manage events."""
         super().__init__(*args, plugin="namecheap")
         self.framework.observe(self.on.config_changed, self._on_config_changed)
 
     @property
     def _namecheap_api_key(self) -> str:
-        return self.model.config.get("namecheap-api-key")
+        return self.model.config.get("namecheap-api-key", "")
 
     @property
     def _namecheap_api_user(self) -> str:
-        return self.model.config.get("namecheap-api-user")
+        return self.model.config.get("namecheap-api-user", "")
 
     @property
     def _namecheap_http_timeout(self) -> Optional[str]:
@@ -72,8 +73,8 @@ class NamecheapLegoK8s(AcmeClient):
             additional_config.update({"NAMECHEAP_HTTP_TIMEOUT": self._namecheap_http_timeout})
         return additional_config
 
-    def _on_config_changed(self, _):
-        """Handles config-changed events."""
+    def _on_config_changed(self, event: EventBase):
+        """Handle config-changed events."""
         if not self._validate_namecheap_config():
             return
         if not self.validate_generic_acme_config():
@@ -81,7 +82,7 @@ class NamecheapLegoK8s(AcmeClient):
         self.unit.status = ActiveStatus()
 
     def _validate_namecheap_config(self) -> bool:
-        """Checks whether required config options are set.
+        """Check whether required config options are set.
 
         Returns:
             bool: True/False

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,18 +1,8 @@
 black
 codespell
 coverage[toml]
-flake8 ==6.1.0
-flake8-copyright
-flake8-builtins
-flake8-docstrings
-isort
 juju
-mypy
-parameterized
-pep8-naming
-pyproject-flake8
+pyright
 pytest
 pytest-operator
-types-PyYAML
-types-setuptools
-types-toml
+ruff

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,14 +10,15 @@ bcrypt==4.1.2
     # via paramiko
 black==24.2.0
     # via -r test-requirements.in
-cachetools==5.3.2
+cachetools==5.3.3
     # via google-auth
-certifi==2023.11.17
+certifi==2024.2.2
     # via
     #   kubernetes
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
@@ -29,27 +30,16 @@ codespell==2.2.6
 coverage[toml]==7.4.3
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==6.1.0
-    # via
-    #   -r test-requirements.in
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.2.0
-    # via -r test-requirements.in
-flake8-copyright==0.2.4
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
-google-auth==2.27.0
+google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
     # via juju
@@ -59,10 +49,8 @@ iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.20.0
+ipython==8.22.2
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
@@ -75,19 +63,16 @@ kubernetes==29.0.0
     # via juju
 macaroonbakery==1.3.4
     # via juju
-markupsafe==2.1.4
+markupsafe==2.1.5
     # via jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
-mypy==1.8.0
-    # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
     #   black
-    #   mypy
     #   typing-inspect
+nodeenv==1.8.0
+    # via pyright
 oauthlib==3.2.2
     # via
     #   kubernetes
@@ -97,25 +82,21 @@ packaging==23.2
     #   black
     #   juju
     #   pytest
-parameterized==0.9.0
-    # via -r test-requirements.in
-paramiko==2.12.0
+paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
 pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.1.0
+platformdirs==4.2.0
     # via black
 pluggy==1.4.0
     # via pytest
 prompt-toolkit==3.0.43
     # via ipython
-protobuf==4.25.2
+protobuf==4.25.3
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
@@ -128,14 +109,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.1.0
-    # via flake8
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -145,13 +122,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==6.1.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pytest==8.0.2
+pyright==1.1.352
+    # via -r test-requirements.in
+pytest==8.1.0
     # via
     #   -r test-requirements.in
     #   pytest-asyncio
@@ -160,12 +137,13 @@ pytest-asyncio==0.21.1
     # via pytest-operator
 pytest-operator==0.34.0
     # via -r test-requirements.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2023.3.post1
+pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -179,16 +157,15 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.0
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
     #   kubernetes
     #   macaroonbakery
-    #   paramiko
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -197,26 +174,20 @@ traitlets==5.14.1
     # via
     #   ipython
     #   matplotlib-inline
-types-pyyaml==6.0.12.12
-    # via -r test-requirements.in
-types-setuptools==69.1.0.20240301
-    # via -r test-requirements.in
-types-toml==0.10.8.7
-    # via -r test-requirements.in
-typing-extensions==4.9.0
-    # via
-    #   mypy
-    #   typing-inspect
+typing-extensions==4.10.0
+    # via typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.1.0
+urllib3==2.2.1
     # via
     #   kubernetes
     #   requests
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,10 +3,9 @@
 
 import unittest
 
+from charm import NamecheapLegoK8s
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
-
-from charm import NamecheapLegoK8s
 
 
 class TestCharm(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,50 +1,48 @@
-# Copyright 2022 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
-skipsdist=True
+no_package = True
 skip_missing_interpreters = True
-envlist = lint, static, unit
+env_list = format, lint, static, unit
+min_version = 4.0.0
 
 [vars]
 src_path = {toxinidir}/src/
 unit_test_path = {toxinidir}/tests/unit/
 integration_test_path = {toxinidir}/tests/integration/
-all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path}
+all_path = {[vars]src_path} {[vars]unit_test_path} {[vars]integration_test_path} 
 
 [testenv]
-setenv =
-  PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=ipdb.set_trace
-  PY_COLORS=1
+set_env =
+    PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-passenv =
-  PYTHONPATH
-  CHARM_BUILD_DIR
-  MODEL_SETTINGS
+pass_env =
+    PYTHONPATH
+    CHARM_BUILD_DIR
+    MODEL_SETTINGS
 
-[testenv:fmt]
+[testenv:format]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
     black {[vars]all_path}
+    ruff --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    codespell {[vars]all_path}
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static]
-description = Run static analysis checks
-setenv =
-    PYTHONPATH = ""
+description = Run static type checks
 commands =
-    mypy {[vars]all_path} {posargs}
+    pyright {posargs}
 
 [testenv:unit]
 description = Run unit tests


### PR DESCRIPTION
# Description

In order to standardise with the new default linter for charms and between TLS projects, we are moving the lint checks from pflake8 and isort to ruff. We also take the opportunity to "rebase" the tox.ini and pyproject.toml files onto what's default coming out of charmcraft init.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
