### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -5,7 +5,7 @@
 """Retrieves certificates from an ACME server using the namecheap dns provider."""
 
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 
 from charms.lego_base_k8s.v0.lego_client import AcmeClient
 from ops.main import main
@@ -22,11 +22,11 @@ class NamecheapLegoK8s(AcmeClient):
 
     @property
     def _namecheap_api_key(self) -> str:
-        return self.model.config.get("namecheap-api-key", "")
+        return cast(str, self.model.config.get("namecheap-api-key", ""))
 
     @property
     def _namecheap_api_user(self) -> str:
-        return self.model.config.get("namecheap-api-user", "")
+        return cast(str, self.model.config.get("namecheap-api-user", ""))
 
     @property
     def _namecheap_http_timeout(self) -> Optional[str]:
@@ -46,7 +46,7 @@ class NamecheapLegoK8s(AcmeClient):
 
     @property
     def _namecheap_sandbox(self) -> Optional[str]:
-        return self.model.config.get("namecheap-sandbox")
+        return cast(str, self.model.config.get("namecheap-sandbox"))
 
     @property
     def _plugin_config(self) -> Dict[str, str]:


### PR DESCRIPTION
# Description

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that validate the behaviour of the software N/A
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules N/A
- [ ] I have bumped the version of the library N/A
