### PR TITLE
chore: use tls requirer from stable risk

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -50,7 +50,7 @@ async def deploy(ops_test: OpsTest, request):
     await ops_test.model.deploy(
         TLS_REQUIRER_CHARM_NAME,
         application_name=TLS_REQUIRER_CHARM_NAME,
-        channel="edge",
+        channel="stable",
     )
 
 


### PR DESCRIPTION
# Description

Use tls requirer from stable risk, reducing the risk of tests failing because of issues in other charms used in tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
