### PR TITLE
chore: Fetches lates version of the lego client lib

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -27,7 +27,10 @@ class TestCharm(unittest.TestCase):
             }
         )
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        self.assertEqual(
+            self.harness.model.unit.status,
+            ActiveStatus("0/0 certificate requests are fulfilled"),
+        )
 
     def test_given_config_changed_when_email_is_invalid_then_status_is_blocked(self):
         self.harness.update_config(


### PR DESCRIPTION
# Description

Fetches lates version of the lego client lib.
Fixes unit tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
