### PR TITLE
style: Format using ruff

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -16,11 +16,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
       parser: The pytest command line parser.
     """
     parser.addoption(
-        "--charm_path",
-        action="store",
-        default=None,
-        help="Path to the charm under test"
+        "--charm_path", action="store", default=None, help="Path to the charm under test"
     )
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Validate the options provided by the user.

--- a/tox.ini
+++ b/tox.ini
@@ -30,12 +30,14 @@ pass_env =
 description = Apply coding style standards to code
 commands =
     ruff check --fix {[vars]all_path}
+    ruff format {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
     codespell {tox_root}
     ruff check {[vars]all_path}
+    ruff format --check {[vars]all_path}
 
 [testenv:static]
 description = Run static type checks


### PR DESCRIPTION
Currently, ruff is only configured to check the files for linting errors. This adds ruff formatting to tox checks.

Review notes:

Only tox.ini contains functional changes, the rest are the result of running tox -e format.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
